### PR TITLE
Fix keypair bug in ApproveAllAssignments.R

### DIFF
--- a/R/ApproveAllAssignments.R
+++ b/R/ApproveAllAssignments.R
@@ -28,7 +28,7 @@ function (hit = NULL, hit.type = NULL, feedback = NULL,
                         GetAssignments(hit = i, return.all = TRUE, keypair = keypair,
                         log.requests = log.requests, sandbox = sandbox)$AssignmentId })
     }
-    request <- ApproveAssignments(keypair, assignments, feedback = feedback,
+    request <- ApproveAssignments(keypair = keypair, assignments, feedback = feedback,
                 print = print, log.requests = log.requests, 
                 sandbox = sandbox, validation.test = validation.test)
     return(request)


### PR DESCRIPTION
Currently the function passes your keypair first to ApproveAssignments without naming the argument, resulting in the ApproveAssignments function attempting to approve 2 assignments: Your keypair credentials. This change fixed it for me.
