### PR TITLE
Fixed issue with recursion trying to parse XML that was already parsed

### DIFF
--- a/R/GetBonuses.R
+++ b/R/GetBonuses.R
@@ -95,8 +95,7 @@ function(assignment = NULL,
         }
         Bonuses <- list()
         for (i in 1:length(hitlist)) {
-            b <- GetBonuses(hit = hitlist[i], return.all = return.all, ...)
-            Bonuses[[i]] <- as.data.frame.BonusPayments(xml.parsed = xmlParse(b$xml))
+          Bonuses[[i]] <- GetBonuses(hit = hitlist[i], return.all = return.all, ...)
         }
         out <- do.call('rbind.data.frame',Bonuses)
         if (verbose) {


### PR DESCRIPTION
The recursive calling of `GetBonuses` when specifying `hit.type` caused the individual bonuses retrieved for each HIT to have a `file.exists` error. `GetBonuses` already parses the XML.