### PR TITLE
Clarified which QualificationTypeIDs can be used

### DIFF
--- a/man/AssignQualification.Rd
+++ b/man/AssignQualification.Rd
@@ -39,7 +39,7 @@ AssignQualification(qual, workers, value = "1", notify = FALSE,
   \item{...}{Additional arguments passed to \code{\link{request}}.}
 }
 \details{
-A very robust function to assign a Qualification to one or more workers. The simplest use of the function is to assign a Qualification of the specified value to one worker, but assignment to multiple workers is possible. Workers can be assigned a Qualification previously created by \code{\link{CreateQualificationType}} or with the characteristics of a new QualificationType specified atomically. Qualifications can also be assigned conditional on each worker's value of a specified statistic (including assigning the value of the specified statistic as the worker's score for the Qualification).
+A very robust function to assign a Qualification to one or more workers. The simplest use of the function is to assign a Qualification of the specified value to one worker, but assignment to multiple workers is possible. Workers can be assigned a Qualification previously created by \code{\link{CreateQualificationType}}, with the characteristics of a new QualificationType specified atomically, or a QualificationTypeID for a qualification created in the MTurk RUI. Qualifications can also be assigned conditional on each worker's value of a specified statistic (including assigning the value of the specified statistic as the worker's score for the Qualification).
 
 \code{AssignQualifications()} and \code{assignqual()} are aliases.
 }


### PR DESCRIPTION
Didn't specify that one can take the QualificationTypeID from a Qualification previously created in the RUI, command line, or other interface.

Please ensure the following before submitting a PR:

 - [ ] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/MTurkR/issues/new) first
 - [ ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/MTurkR/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/MTurkR/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [ ] add code or new test files to [`/tests`](https://github.com/cloudyr/MTurkR/tree/master/tests/testthat) for any new functionality or bug fix
 - [ ] make sure `R CMD check` runs without error before submitting the PR

